### PR TITLE
Some renaming, formatting and cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
-# elm-cursor  
-Alternative way to build elm app, 
-this module contains all low level primitives 
-to build elm app with high level cursor abstraction.
+# elm-cursor
 
-There will be an block article and more examples. It's just a first release.
+Alternative way to build elm apps. This module contains all low level primitives
+to build elm apps with high level cursor abstraction.
+
+Minimal cursor-powered application looks like this:
+
+```elm
+module Minimal where
+
+import Graphics.Element exposing (show)
+
+import Cursor
+
+main =
+  Cursor.start model view
+
+model =
+  "Hello World!"
+
+view =
+  show << Cursor.get
+```
+
+More examples can be found in ``examples/`` folder.

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "2.0.0",
     "summary": "Reactive cursors for elm",
     "repository": "https://github.com/ir4y/elm-cursor.git",
     "license": "BSD3",

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "summary": "Examples for elm-cursor",
-    "repository": "https://github.com/ir4y/cursoe.git",
+    "repository": "https://github.com/ir4y/elm-cursor.git",
     "license": "BDS3",
     "source-directories": [
         "src"

--- a/examples/src/Counter/Counter.elm
+++ b/examples/src/Counter/Counter.elm
@@ -1,36 +1,46 @@
-module Counter.Counter (view) where
+module Counter.Counter
+  ( view, countStyle
+  ) where
 
-import Cursor exposing(..)
-import Html exposing (Html, text, div, button)
-import Html.Attributes exposing (style)
-import Html.Events exposing (on)
 import Json.Decode as Json
 
+import Html exposing (Html, Attribute, text, div, button)
+import Html.Attributes exposing (style)
+import Html.Events exposing (on)
 
-
-dec_ a =
-  a - 1
-
-
-inc_ a =
-  a + 1
+import Cursor exposing (Cursor)
 
 
 view: Cursor a Int -> Html.Html
 view cursor =
-  div []
-        [ button [ on "click" Json.value <| \_ -> updateC cursor dec_] [ text "-" ]
-        , div [ countStyle ] [ text << toString <| getC cursor]
-        , button [ on "click" Json.value <| \_ -> updateC cursor inc_] [ text "+" ]
+  let
+    btn f t =
+      button
+        [ on "click" Json.value
+            <| \_ -> Cursor.update cursor f
         ]
+        [ text t ]
+
+    dec_ a = a - 1
+
+    inc_ a = a + 1
+  in
+    div []
+      [ btn inc_ "+"
+      , div [ countStyle ] [ text <| toString <| Cursor.get cursor ]
+      , btn dec_ "-"
+      ]
 
 
-countStyle : Html.Attribute
+countStyle : Attribute
 countStyle =
-  style
-    [ ("font-size", "20px")
-    , ("font-family", "monospace")
-    , ("display", "inline-block")
-    , ("width", "50px")
-    , ("text-align", "center")
-    ]
+  let
+    (=>) = (,)
+  in
+    style
+      [ "font-size" => "20px"
+      , "font-family" => "monospace"
+      , "display" => "inline-block"
+      , "width" => "50px"
+      , "text-align" => "center"
+      ]

--- a/examples/src/Counter/Single.elm
+++ b/examples/src/Counter/Single.elm
@@ -1,28 +1,32 @@
-module Single where
+module Counter.Single where
 
-import Cursor exposing(..)
-import Counter.Counter as Counter
-import Focus exposing((=>))
-import Html exposing (Html)
 import Json.Decode as Json
+import Signal exposing (Signal)
+
+import Html exposing (Html)
+
+import Focus exposing (Focus, (=>))
+
+import Cursor exposing (Cursor, (>=>))
+
+import Counter.Counter as Counter
 
 
 type alias Store =
-  { counter: Int
+  { counter_: Int
   }
 
 
-counterL : Focus.Focus Store Int
-counterL =
-  Focus.create .counter (\f r -> { r | counter = f r.counter })
+counter : Focus Store Int
+counter =
+  Focus.create .counter_ (\f r -> { r | counter_ = f r.counter_ })
 
 
-view : Cursor Store Store -> Html.Html
+view : Cursor Store Store -> Html
 view cursor =
-  let
-     counter = cursor >=> counterL
-  in Counter.view counter
+  Counter.view <| cursor >=> counter
 
 
+main : Signal Html
 main =
-  drawC {counter = 0} view
+  Cursor.start { counter_ = 0 } view

--- a/examples/src/Greeting.elm
+++ b/examples/src/Greeting.elm
@@ -1,42 +1,51 @@
-import Cursor exposing(..)
-import Focus exposing((=>))
+module Greeting where
+
 import Html exposing (Html, text, p, div)
 import Html.Attributes as Attributes
 import Html.Events exposing (on, targetValue)
-import Json.Decode as Json
+
+import Focus exposing (Focus)
+
+import Cursor exposing (Cursor, (>=>))
 
 
 type alias Store =
-  { value: String
+  { value_: String
   }
 
 
-valueL : Focus.Focus Store String
-valueL =
-  Focus.create .value (\f r -> { r | value = f r.value })
+value : Focus Store String
+value =
+  Focus.create .value_ (\f r -> { r | value_ = f r.value_ })
 
 
-view : Cursor Store Store -> Html.Html
+view : Cursor Store Store -> Html
 view cursor =
-  let
-     value = cursor >=> valueL
-  in div [] [ view_input value ]
+  viewInput <| cursor >=> value
+
 
 input : Cursor a String -> Html
 input cursor =
-    Html.input [ Attributes.value <| getC cursor
-               , on "input" targetValue <| setC cursor
-               ] []
+  Html.input
+    [ Attributes.value <| Cursor.get cursor
+    , on "input" targetValue <| Cursor.set cursor
+    ] []
 
-view_input : Cursor Store String -> Html.Html
-view_input cursor =
-  div [] [ p [] [ text "Hello: "
-                , text <| getC cursor
-                , text " !"
-                ]
-         , p [] [ input cursor
-                ]
-         ]
 
+viewInput : Cursor Store String -> Html
+viewInput cursor =
+  div []
+    [ p []
+        [ text "Hello: "
+        , text <| Cursor.get cursor
+        , text " !"
+        ]
+    , p []
+        [ input cursor
+        ]
+    ]
+
+
+main : Signal Html
 main =
-  drawC {value = ""} view
+  Cursor.start { value_ = "" } view

--- a/examples/src/Minimal.elm
+++ b/examples/src/Minimal.elm
@@ -1,0 +1,14 @@
+module Minimal where
+
+import Graphics.Element exposing (show)
+
+import Cursor
+
+main =
+  Cursor.start model view
+
+model =
+  "Hello World!"
+
+view =
+  show << Cursor.get


### PR DESCRIPTION
Now public API looks like:
- `get`,`set`,`update` without any suffixes (because most of imports are usually qualified - `Cursor.get`),
- `start` now replaces `drawC` (in a manner of `StartApp.start`),
- `cursor` now replaces `createC` - "smart constructor" with name which equals to the name of type.

All examples now formatted and linted, all functions now has proper annotations.

Some typos was fixed too.

Because of changes in API the package version was bumped to `2.0.0`.
